### PR TITLE
Fix typo in plugin descriptor keys

### DIFF
--- a/plugins/ca-cert.yaml
+++ b/plugins/ca-cert.yaml
@@ -14,7 +14,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "master"
-  shortDesciption: Print the PEM CA certificate of the current cluster 
+  shortDescription: Print the PEM CA certificate of the current cluster 
   description: |
     Pretty print the current cluster certificate.
     The plugin formats the certificate

--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -41,4 +41,4 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [windows]}
   version: "v0.0.1"
-  shortDesciption: Install plugins
+  shortDescription: Install plugins


### PR DESCRIPTION
In #2 the fields contain a typo. This leads to validation errors