### PR TITLE
Add a new plugin "view-kubeconfig"

### DIFF
--- a/plugins/view-kubeconfig.yaml
+++ b/plugins/view-kubeconfig.yaml
@@ -1,0 +1,25 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha1
+kind: Plugin
+metadata:
+  name: view-kubeconfig
+spec:
+  platforms:
+  - uri: https://github.com/superbrothers/kubectl-view-kubeconfig-plugin/releases/download/v1.0.2/view-kubeconfig-darwin-amd64.zip
+    sha256: 06922a137ceeed2b82ceef9c86a150b3998c6552a1cd82bdcc6119b9d0868100
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: darwin
+  - uri: https://github.com/superbrothers/kubectl-view-kubeconfig-plugin/releases/download/v1.0.2/view-kubeconfig-linux-amd64.zip
+    sha256: e483c2a282c830a22e235b418e5f530c5f51c72da31279ef3457c63307cb0ec3
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: linux
+  version: v1.0.2
+  shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
+  description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
This PR adds a new plugin "view-kubeconfig". This kubectl plugin shows a kubeconfig to access the apiserver with a specified serviceaccount.

- https://github.com/superbrothers/kubectl-view-kubeconfig-plugin

## Examples

```
# Show a kubeconfig setting of serviceaccount/default
$ kubectl plugin view-kubeconfig default
```