### PR TITLE
Add a new plugin "view-serviceaccount-kubeconfig"

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -1,0 +1,25 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha1
+kind: Plugin
+metadata:
+  name: view-serviceaccount-kubeconfig
+spec:
+  platforms:
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v1.1.0/view-serviceaccount-kubeconfig-darwin-amd64.zip
+    sha256: 67db6838c3a832dde88eadee12c96e1b0f78599a63b15b5c7aa73a7b155500da
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: darwin
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v1.1.0/view-serviceaccount-kubeconfig-linux-amd64.zip
+    sha256: 374d35f46bfd7eea91f82a814b42bf0c4989c085d9ea941d8ada0294908c9fc3
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: linux
+  version: v1.1.0
+  shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
+  description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
This kubectl plugin shows a kubeconfig to access the apiserver with a
specified serviceaccount.

```
$ kubectl plugin view-serviceaccount-kubeconfig -h
Show a kubeconfig setting to access the apiserver with a specified serviceaccount.

You can also use "view-sa-kubeconfig" as alias for this plugin.

Examples:
  # Show a kubeconfig setting of serviceaccount/default
  kubectl plugin view-serviceaccount-kubeconfig default

Usage:
  kubectl plugin view-serviceaccount-kubeconfig [flags] [options]

Use "kubectl options" for a list of global command-line options (applies to all commands).
```

- https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin

/ref #13 