### PR TITLE
migration to krew v1alpha2 (v0.2) manifest model

### DIFF
--- a/plugins/ca-cert.yaml
+++ b/plugins/ca-cert.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: ca-cert
@@ -7,6 +7,7 @@ spec:
   - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
     sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
     uri: https://github.com/ahmetb/kubectl-extras/archive/c403c5714a4442b8314e5a86b0ff63f7a815f83f.zip
+    bin: ca-cert.bash
     files:
     - from: "/*/ca-cert/*"
       to: "."
@@ -14,11 +15,10 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "master"
-  shortDescription: Print the PEM CA certificate of the current cluster 
+  shortDescription: Print the PEM CA certificate of the current cluster
   description: |
-    Pretty print the current cluster certificate.
-    The plugin formats the certificate
-    in PEM format described in RFC1421.
+    Pretty print the current cluster certificate. The plugin formats the
+    certificate in PEM format described in RFC1421.
   caveats: |
     This plugin needs the following programs:
     * base64

--- a/plugins/debug-shell.yaml
+++ b/plugins/debug-shell.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: debug-shell
@@ -6,6 +6,7 @@ spec:
   platforms:
   - uri: https://github.com/danisla/kubefunc/archive/v1.0.2.zip
     sha256: 93c01f4b4f0862409dfbb10cb48995b70540f359e08742f0f10f7adf9d4326bd
+    bin: debug-shell.sh
     files:
     - from: "/*/debug-shell/*"
       to: "."
@@ -13,4 +14,4 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.2"
-  shortDescription: Create pod with interactive shell
+  shortDescription: Create pod with interactive kube-shell.

--- a/plugins/exec-all.yaml
+++ b/plugins/exec-all.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: exec-all
@@ -6,6 +6,7 @@ spec:
   platforms:
   - uri: "https://github.com/jpdasma/kubectl-exec-all/archive/v1.0.0.zip"
     sha256: "93f4da0b9127833924ede21d1ac1452a189e23b54339d8eeac1623a89dbfbd17"
+    bin: exec-all.sh
     files:
     - from: "/*/unix/*"
       to: "."
@@ -15,6 +16,8 @@ spec:
   version: "v1.0.0"
   shortDescription: "Execute a command in all of the containers in a specified resource"
   caveats: |
+    Usage:
+      kubectl plugin exec-all <RESOURCE_TYPE> <RESOURCE_NAME> -- <COMMAND>
     This plugin needs the following programs:
     * jq
     * xargs

--- a/plugins/gke-credentials.yaml
+++ b/plugins/gke-credentials.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: gke-credentials
@@ -7,6 +7,7 @@ spec:
   - head: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
     sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
     uri: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
+    bin: gke-credentials.sh
     files:
     - from: "/*/gke-credentials/*"
       to: "."

--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: krew
@@ -6,6 +6,7 @@ spec:
   platforms:
   - uri: https://github.com/GoogleContainerTools/krew/releases/download/v0.1.1/krew.zip
     sha256: 308989054b891cde0639d8405ea04a18c22e8461ed695b08163c52f1756b7d41
+    bin: krew
     files:
     - from: "out/build/unix/plugin.yaml"
       to: "plugin.yaml"
@@ -18,6 +19,7 @@ spec:
       - {key: os, operator: In, values: [darwin]}
   - uri: https://github.com/GoogleContainerTools/krew/releases/download/v0.1.1/krew.zip
     sha256: 308989054b891cde0639d8405ea04a18c22e8461ed695b08163c52f1756b7d41
+    bin: krew
     files:
     - from: "out/build/unix/plugin.yaml"
       to: "plugin.yaml"
@@ -30,6 +32,7 @@ spec:
       - {key: os, operator: In, values: [linux]}
   - uri: https://github.com/GoogleContainerTools/krew/releases/download/v0.1.1/krew.zip
     sha256: 308989054b891cde0639d8405ea04a18c22e8461ed695b08163c52f1756b7d41
+    bin: krew.exe
     files:
     - from: "out/build/windows/plugin.yaml"
       to: "plugin.yaml"

--- a/plugins/mtail.yaml
+++ b/plugins/mtail.yaml
@@ -1,12 +1,13 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: mtail
 spec:
   platforms:
   - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
-    sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
-    uri: https://github.com/ahmetb/kubectl-extras/archive/c403c5714a4442b8314e5a86b0ff63f7a815f83f.zip
+    sha256: 4cf181eb79b1527c20ceff4dba072a8db897ef448e5b276e2d2d70b0a61e6282
+    uri: https://github.com/ahmetb/kubectl-extras/archive/3802e1cae8c037e73d0fec7bc9519c1bca9d25a1.zip
+    bin: mtail.sh
     files:
     - from: "/*/mtail/*"
       to: "."

--- a/plugins/node-admin.yaml
+++ b/plugins/node-admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: node-admin
@@ -6,6 +6,7 @@ spec:
   platforms:
   - uri: https://github.com/danisla/kubefunc/archive/v1.0.2.zip
     sha256: 93c01f4b4f0862409dfbb10cb48995b70540f359e08742f0f10f7adf9d4326bd
+    bin: node-admin.sh
     files:
     - from: "/*/node-admin/*"
       to: "."

--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -1,26 +1,28 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: open-svc
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v1.2.0/open-svc-darwin-amd64.zip
-    sha256: 92e21f890c8fed584fe16f4e7cfbb707c8fbc95de286422e06a66ac550040ac5
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.0.0/kubectl-open_svc-darwin-amd64.zip
+    sha256: 8b8c17a9591473a7a42973dd439c0bed3476bee49f72db3753fbb73e81a50ff6
+    bin: kubectl-open_svc
     files:
-    - from: "*"
+    - from: "kubectl-open_svc"
       to: "."
     selector:
       matchLabels:
         os: darwin
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v1.2.0/open-svc-linux-amd64.zip
-    sha256: b4467fc8e0d3a1f23450282710fb82f360242c5fe405a016eb9c274b900c3b93
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.0.0/kubectl-open_svc-linux-amd64.zip
+    sha256: bf3317f81e44a4a453704fd7a2cfff7fa6a0c9ad4971bcfd7feb33107b7af0f3
+    bin: kubectl-open_svc
     files:
-    - from: "*"
+    - from: "kubectl-open_svc"
       to: "."
     selector:
       matchLabels:
         os: linux
-  version: v1.2.0
+  version: v2.0.0
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser

--- a/plugins/pod-logs.yaml
+++ b/plugins/pod-logs.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: pod-logs
@@ -7,6 +7,7 @@ spec:
   - head: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
     sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
     uri: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
+    bin: pod-logs.sh
     files:
     - from: "/*/pod-logs/*"
       to: "."

--- a/plugins/pod-shell.yaml
+++ b/plugins/pod-shell.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: pod-shell
@@ -7,6 +7,7 @@ spec:
   - head: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
     sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
     uri: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
+    bin: pod-shell.sh
     files:
     - from: "/*/pod-shell/*"
       to: "."
@@ -15,4 +16,3 @@ spec:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.1"
   shortDescription: Display a list of pods to execute a shell in
-  

--- a/plugins/restart.yaml
+++ b/plugins/restart.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: "restart"
@@ -6,6 +6,7 @@ spec:
   platforms:
   - uri: https://github.com/achanda/kubectl-restart/archive/v0.0.3.zip
     sha256: d7079b79bf4e10e55ded435a2e862efe310e019b6c306a8ff04191238ef4b2b4
+    bin: restart.sh
     files:
     - from: "/kubectl-restart-*/*"
       to: "."

--- a/plugins/rm-standalone-pods.yaml
+++ b/plugins/rm-standalone-pods.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: rm-standalone-pods
@@ -7,6 +7,7 @@ spec:
   - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
     sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
     uri: https://github.com/ahmetb/kubectl-extras/archive/c403c5714a4442b8314e5a86b0ff63f7a815f83f.zip
+    bin: rm-standalone-pods.bash
     files:
     - from: "/*/rm-standalone-pods/*"
       to: "."

--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -1,12 +1,13 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: view-secret
 spec:
   platforms:
   - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
-    sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
-    uri: https://github.com/ahmetb/kubectl-extras/archive/c403c5714a4442b8314e5a86b0ff63f7a815f83f.zip
+    sha256: 208fde0b9f42ef71f79864b1ce594a70832c47dc5426e10ca73bf02e54d499d0
+    uri: https://github.com/ahmetb/kubectl-extras/archive/b16b7c43a28240ed280c03b20e6a2f232f992479.zip
+    bin: view-secret.sh
     files:
     - from: "/*/view-secret/*"
       to: "."

--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: krew.googlecontainertools.github.com/v1alpha1
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: view-serviceaccount-kubeconfig
@@ -6,16 +6,18 @@ spec:
   platforms:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v1.1.0/view-serviceaccount-kubeconfig-darwin-amd64.zip
     sha256: 67db6838c3a832dde88eadee12c96e1b0f78599a63b15b5c7aa73a7b155500da
+    bin: view-serviceaccount-kubeconfig
     files:
-    - from: "*"
+    - from: "view-serviceaccount-kubeconfig"
       to: "."
     selector:
       matchLabels:
         os: darwin
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v1.1.0/view-serviceaccount-kubeconfig-linux-amd64.zip
     sha256: 374d35f46bfd7eea91f82a814b42bf0c4989c085d9ea941d8ada0294908c9fc3
+    bin: view-serviceaccount-kubeconfig
     files:
-    - from: "*"
+    - from: "view-serviceaccount-kubeconfig"
       to: "."
     selector:
       matchLabels:


### PR DESCRIPTION
- added bin fields and updated apiVersion
- tested each plugin manually, many broken due to kubectl no longer passing any
  KUBECTL_ env vars anytime soon.
  - only open-svc had a release that intentionally supports v1.12
  - opened issues to other plugin repos. if we can't get fix anytime soon,
    we should consider removing from the index
  - many kubectl-extras were broken, but I made commits to remove namespace
    choosing support for now

#### Checklist

- [x] Verify the installation from URL works (`kubectl plugin install --source`)