### PR TITLE
Bump up the version of view-serviceaccount-kubeconfig to 2.0.0.

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,24 +4,24 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v1.1.0/view-serviceaccount-kubeconfig-darwin-amd64.zip
-    sha256: 67db6838c3a832dde88eadee12c96e1b0f78599a63b15b5c7aa73a7b155500da
-    bin: view-serviceaccount-kubeconfig
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.0.0/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
+    sha256: e5394ff39cdc5906a54e0acfd03a31a609b12dce78a88fd66ede48727df1416c
+    bin: kubectl-view_serviceaccount_kubeconfig
     files:
-    - from: "view-serviceaccount-kubeconfig"
+    - from: "kubectl-view_serviceaccount_kubeconfig"
       to: "."
     selector:
       matchLabels:
         os: darwin
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v1.1.0/view-serviceaccount-kubeconfig-linux-amd64.zip
-    sha256: 374d35f46bfd7eea91f82a814b42bf0c4989c085d9ea941d8ada0294908c9fc3
-    bin: view-serviceaccount-kubeconfig
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.0.0/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: 611c5b5fa13b31e6b4f3c38dd169f821b96b4c19f5a5b31845a6eb42ecdb9a31
+    bin: kubectl-view_serviceaccount_kubeconfig
     files:
-    - from: "view-serviceaccount-kubeconfig"
+    - from: "kubectl-view_serviceaccount_kubeconfig"
       to: "."
     selector:
       matchLabels:
         os: linux
-  version: v1.1.0
+  version: v2.0.0
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
view-serviceaccount-kubeconfig migrated to kubectl 1.12 in the v2.0.0 release.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md)
- [x] Verify the installation from URL works (`kubectl krew install --manifest` ~~`kubectl plugin install --source`~~)
