### PR TITLE
RBAC View added to plugins

### DIFF
--- a/plugins/rbac-view.yaml
+++ b/plugins/rbac-view.yaml
@@ -1,0 +1,55 @@
+# Copyright © 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rbac-view
+spec:
+  version: "v0.1.0"
+  shortDescription: A tool to visualize your RBAC permissions.
+  caveats: |
+    Run "kubectl rbac-view" to open a browser with an html view of your permissions.
+    You can find documentation at https://github.com/jasonrichardsmith/rbac-view.
+  platforms:
+  - uri: https://github.com/jasonrichardsmith/rbac-view/releases/download/v0.1.0/rbac-view.v0.1.0.darwin.tar.gz
+    sha256: 2a3a6cca926bfa2c4116b76f376047946f4188f7f2129ac3c5cb9fe29b7c176d
+    bin: rbac-view
+    files:
+    - from: bin/darwin/rbac-view
+      to: rbac-view
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/jasonrichardsmith/rbac-view/releases/download/v0.1.0/rbac-view.v0.1.0.linux.tar.gz
+    sha256: 161e6128240f6ef4955f69d428aeea5f93f893775c0e984a3e32ea5835a32804
+    bin: rbac-view
+    files:
+    - from: bin/linux/rbac-view
+      to: rbac-view
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - uri: https://github.com/jasonrichardsmith/rbac-view/releases/download/v0.1.0/rbac-view.v0.1.0.windows.tar.gz
+    sha256: 1cde799e12658ed305f1d4fe20900fef591b4b174fa22d1494a8a9dfe15726c5
+    bin: rbac-view
+    files:
+    - from: bin/windows/rbac-view
+      to: rbac-view
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64


### PR DESCRIPTION
Adding RBAC View as a plug in.
https://github.com/jasonrichardsmith/rbac-view

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
