### PR TITLE
Add cssh plugin v1.0.0

### DIFF
--- a/plugins/cssh.yaml
+++ b/plugins/cssh.yaml
@@ -1,0 +1,25 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cssh
+spec:
+  version: "v1.0.0"
+  platforms:
+  - uri: https://github.com/containership/kubectl-cssh/archive/v1.0.0.tar.gz
+    sha256: c638dcc802d2d52ce0ec2283a2f9d217eaa17855f3edd702229571da39c1ab84
+    bin: kubectl-cssh
+    files:
+    - from: "/*/parse-args.sh"
+      to: "."
+    - from: "/*/kubectl-cssh"
+      to: "."
+    selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+  caveats: |
+    This plugin needs the following programs:
+    * tmux
+  description: |
+    This plugin allows users to SSH into one more more Kubernetes nodes
+    within separate tmux panes.
+  shortDescription: SSH into Kubernetes nodes


### PR DESCRIPTION
This PR adds [cssh plugin](https://github.com/containership/kubectl-cssh) v1.0.0 to krew as "cssh", which can be invoked with `kubectl cssh`.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)