### PR TITLE
add prompt plugin v1.0.0-krew

### DIFF
--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -6,7 +6,7 @@ spec:
   platforms:
   - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
     uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
-    sha256: d12d3c0c9cf2559100adbd7bd032ecf1fc01e09cb8731726ead42a49d6104a4d
+    sha256: 708c3c91cf0be5d859797b13e85ba4a0b9f74921d4e3a4db65de914a07133a17
     bin: kubectl-prompt
     files:
     - from: "*/kubectl-prompt"

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -6,7 +6,7 @@ spec:
   platforms:
   - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
     uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
-    sha256: 21099ad3c3a6509a4ddb94aa0a88c055437e369c41c0e5c0cae49dc6db697241
+    sha256: c020d4d283461ef9f103fd0baa218e9c72612395ff936fd337e165d054cee699
     bin: kubectl-prompt
     files:
     - from: "*/kubectl-prompt"

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -6,7 +6,7 @@ spec:
   platforms:
   - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
     uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
-    sha256: c020d4d283461ef9f103fd0baa218e9c72612395ff936fd337e165d054cee699
+    sha256: d12d3c0c9cf2559100adbd7bd032ecf1fc01e09cb8731726ead42a49d6104a4d
     bin: kubectl-prompt
     files:
     - from: "*/kubectl-prompt"

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -15,6 +15,18 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.0-krew"
-  caveats: When removing this plugin, delete the line beginning with `function kubectl()` in your ~/.bash_profile
+  caveats: |
+    This plugin requires bash.
+    When removing this plugin, delete the line beginning with `function kubectl()` and `KUBECTL_*_PROMPT` in your ~/.bash_profile.
+    See `https://github.com/jordanwilson230/kubectl-plugins#kubectl-prompt` for documentation.
   shortDescription: Prompts for user confirmation when executing commands in critical namespaces or clusters, i.e., production.
-  description: Protect your production environments! When issuing certain commands inside a specified namespace/cluster, a warning prompt appears, telling the user they are in a flagged environment and asks to confirm the command. Ex., `kubectl prompt`, `kubectl prompt add -n production`, kubectl prompt add -c `prod-cluster`. `kubectl prompt list`.
+  description: |
+    Protect your production environments!
+    When issuing certain commands inside a specified namespace/cluster, a warning prompt will appear.
+    This will alert the user that they are in a flagged environment and require a confirmation before executing the command.
+    See `https://github.com/jordanwilson230/kubectl-plugins#kubectl-prompt` for documentation.
+    Usage:
+        View description)            kubectl prompt
+        Flag a namespace)            kubectl prompt add -n production
+        Flag a cluster)              kubectl prompt add -c my-production-cluster
+        View flagged environments)   kubectl prompt list

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -17,4 +17,4 @@ spec:
   version: "v1.0.0-krew"
   caveats: When removing this plugin, delete the line beginning with `function kubectl()` in your ~/.bash_profile
   shortDescription: Prompts for user confirmation when executing commands in critical namespaces or clusters, i.e., production.
-  description: Protect your production environments! When issuing certain commands inside a specified namespace/cluster, a warning prompt appears, telling the user they are in a flagged environment and asks to confirm the command. Ex., `kubectl prompt`, `kubectl add -n production`, kubectl add -c `prod-cluster`. `kubectl prompt list`.
+  description: Protect your production environments! When issuing certain commands inside a specified namespace/cluster, a warning prompt appears, telling the user they are in a flagged environment and asks to confirm the command. Ex., `kubectl prompt`, `kubectl prompt add -n production`, kubectl prompt add -c `prod-cluster`. `kubectl prompt list`.

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -6,7 +6,7 @@ spec:
   platforms:
   - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
     uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
-    sha256: 708c3c91cf0be5d859797b13e85ba4a0b9f74921d4e3a4db65de914a07133a17
+    sha256: efa1c2122ecaeb0a43ba1ed9e54c1ff1274d20de76934f7bb91dd154f2327aa1
     bin: kubectl-prompt
     files:
     - from: "*/kubectl-prompt"

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -1,0 +1,20 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: prompt
+spec:
+  platforms:
+  - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
+    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
+    sha256: 21099ad3c3a6509a4ddb94aa0a88c055437e369c41c0e5c0cae49dc6db697241
+    bin: kubectl-prompt
+    files:
+    - from: "*/kubectl-prompt"
+      to: "."
+    selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+  version: "v1.0.0-krew"
+  caveats: When removing this plugin, delete the line beginning with `function kubectl()` in your ~/.bash_profile
+  shortDescription: Prompts for user confirmation when executing commands in critical namespaces or clusters, i.e., production.
+  description: Protect your production environments! When issuing certain commands inside a specified namespace/cluster, a warning prompt appears, telling the user they are in a flagged environment and asks to confirm the command. Ex., `kubectl prompt`, `kubectl add -n production`, kubectl add -c `prod-cluster`. `kubectl prompt list`.


### PR DESCRIPTION
Adds the prompt plugin seen [here](https://github.com/jordanwilson230/kubectl-plugins#kubectl-prompt).

Verified installation via release url.

This plugin allows a user to flag a certain namespace or cluster, which will then prompt for confirmation when executing commands in the given environment.



-----

**Checklist for plugin developers:**

- [ ✔️ ] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [ ✔️  ] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
