### PR TITLE
Add kubectl-warp v0.0.1

### DIFF
--- a/plugins/warp.yaml
+++ b/plugins/warp.yaml
@@ -1,0 +1,35 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: warp
+spec:
+  version: "v0.0.1"
+  shortDescription: Sync and execute local files in Pod
+  description: |
+    This plugin is like `kubectl run` with `rsync`.
+    It creates temporary Pod and synchronises your local files to 
+    the desired container and executes any command.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/ernoaapa/kubectl-warp/releases/download/v0.0.1/kubectl-warp_0.0.1_linux_amd64.tar.gz
+    sha256: "994bc452922a51cff12ec145f3037e4e5f3696b4c149aa7e492a46fa697f6228"
+    files:
+    - from: kubectl-warp
+      to: "."
+    bin: ./kubectl-warp
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/ernoaapa/kubectl-warp/releases/download/v0.0.1/kubectl-warp_0.0.1_darwin_amd64.tar.gz
+    sha256: "49d9de7dd76d3a11a3e73860be26570b646cccce47af43e448907886b52154c4"
+    files:
+    - from: kubectl-warp
+      to: "."
+    bin: ./kubectl-warp
+  caveats: |
+    This plugin needs the following programs:
+    * rsync


### PR DESCRIPTION
-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)

Fixes ernoaapa/kubectl-warp#4