### PR TITLE
kubectl interactive plugin manifest added to krew-index

### DIFF
--- a/plugins/interactive.yaml
+++ b/plugins/interactive.yaml
@@ -5,13 +5,13 @@ metadata:
 spec:
   version: "v1.1.0-beta"      
   platforms:
-  - selector:             
-      matchLabels:
-        os: linux
+  - selector:
+      matchExpressions:
+        - {key: os, operator: In, values: [darwin, linux]}
     uri: https://github.com/emreodabas/kubectl-plugins/archive/v1.1.0-beta.tar.gz
     sha256: "80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7"
     files:                     
-    - from: kubectl-plugins-1.1.0-beta/kubectl-it
+    - from: kubectl-plugins-*/kubectl-it
       to: kubectl-interactive
     bin: ./kubectl-interactive  
   shortDescription: Prints the environment variables.

--- a/plugins/interactive.yaml
+++ b/plugins/interactive.yaml
@@ -1,0 +1,23 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: interactive               
+spec:
+  version: "v1.1.0-beta"      
+  platforms:
+  - selector:             
+      matchLabels:
+        os: linux
+    uri: https://github.com/emreodabas/kubectl-plugins/archive/v1.1.0-beta.tar.gz
+    sha256: "80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7"
+    files:                     
+    - from: kubectl-plugins-1.1.0-beta/kubectl-it
+      to: kubectl-interactive
+    bin: ./kubectl-interactive  
+  shortDescription: Prints the environment variables.
+  caveats: |
+    This plugin needs the following programs:
+    * fzf
+  description: |
+   kubectl interactive execute exec, edit, delete and log commands with interactive selection.
+          <!-- https://github.com/emreodabas/kubectl-plugins -->


### PR DESCRIPTION
-----
interactive plugin -> 
https://github.com/emreodabas/kubectl-plugins/blob/master/README.md#kubectl-interactive-in-krew-repo-same-as-kubectl-it
**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
