### PR TITLE
kubectl bulk plugin manifest added to krew-index

### DIFF
--- a/plugins/bulk-action.yaml
+++ b/plugins/bulk-action.yaml
@@ -3,25 +3,28 @@ kind: Plugin
 metadata:
   name: bulk-action
 spec:
-  version: "v1.1.0-beta"
+  version: v1.1.0-beta
   platforms:
     - selector:
        matchExpressions:
-       - {key: os, operator: In, values: [darwin, linux]}
+       - key: os
+         operator: In
+         values: ["darwin", "linux"]
       uri: https://github.com/emreodabas/kubectl-plugins/archive/v1.1.0-beta.tar.gz
-      sha256: "80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7"
+      sha256: 80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7
       files:
         - from: kubectl-plugins-*/kubectl-bulk
           to: kubectl-bulk-action
       bin: ./kubectl-bulk-action
-  shortDescription: Bulk get|list|create|update|delete|remove|rollout actions
+  shortDescription: Do bulk actions on Kubernetes resources.
   caveats: |
-    Check the documentation on
-    <!-- https://github.com/emreodabas/kubectl-plugins#kubectl-bulk -->
+    Usage:
+      kubectl bulk-action <get resourceTypes> (get|list|create|update|delete|remove|rollout) <command parameters>
+    
+    Read the documentation at:
+      https://github.com/emreodabas/kubectl-plugins
     This plugin needs the following programs:
     * grep
     * sed
   description: |
-    This plugin do bulk actions on Kubernetes resources.
-    kubectl bulk-action <get resourceTypes> (get|list|create|update|delete|remove|rollout) <command parameters>
-          <!-- https://github.com/emreodabas/kubectl-plugins -->
+    This plugin allows you to do bulk actions on Kubernetes resources.

--- a/plugins/bulk-action.yaml
+++ b/plugins/bulk-action.yaml
@@ -1,7 +1,7 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: bulk
+  name: bulk-action
 spec:
   version: "v1.1.0-beta"
   platforms:
@@ -12,18 +12,16 @@ spec:
       sha256: "80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7"
       files:
         - from: kubectl-plugins-*/kubectl-bulk
-          to: "."
-      bin: ./kubectl-bulk
-  shortDescription: Prints the environment variables.
+          to: kubectl-bulk-action
+      bin: ./kubectl-bulk-action
+  shortDescription: Bulk get|list|create|update|delete|remove|rollout actions
   caveats: |
-    Check documentation on
+    Check the documentation on
     <!-- https://github.com/emreodabas/kubectl-plugins#kubectl-bulk -->
     This plugin needs the following programs:
     * grep
     * sed
   description: |
-    This plugin useful for Bulk operations.
-    You can easily do bulk operations on all resource types like deployments, services, pods etc.
-    Bulk plugin has two part, first you select resources with bulk command, then chose your command 
-    (get|list|create|update|delete|remove|rollout) with parameters.      
+    This plugin do bulk actions on Kubernetes resources.
+    kubectl bulk-action <get resourceTypes> (get|list|create|update|delete|remove|rollout) <command parameters>
           <!-- https://github.com/emreodabas/kubectl-plugins -->

--- a/plugins/bulk.yaml
+++ b/plugins/bulk.yaml
@@ -16,6 +16,8 @@ spec:
       bin: ./kubectl-bulk
   shortDescription: Prints the environment variables.
   caveats: |
+    Check documentation on
+    <!-- https://github.com/emreodabas/kubectl-plugins#kubectl-bulk -->
     This plugin needs the following programs:
     * grep
     * sed

--- a/plugins/bulk.yaml
+++ b/plugins/bulk.yaml
@@ -6,12 +6,12 @@ spec:
   version: "v1.1.0-beta"
   platforms:
     - selector:
-        matchLabels:
-          os: linux
+       matchExpressions:
+       - {key: os, operator: In, values: [darwin, linux]}
       uri: https://github.com/emreodabas/kubectl-plugins/archive/v1.1.0-beta.tar.gz
       sha256: "80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7"
       files:
-        - from: kubectl-plugins-1.1.0-beta/kubectl-bulk
+        - from: kubectl-plugins-*/kubectl-bulk
           to: "."
       bin: ./kubectl-bulk
   shortDescription: Prints the environment variables.

--- a/plugins/bulk.yaml
+++ b/plugins/bulk.yaml
@@ -1,0 +1,27 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: bulk
+spec:
+  version: "v1.1.0-beta"
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+      uri: https://github.com/emreodabas/kubectl-plugins/archive/v1.1.0-beta.tar.gz
+      sha256: "80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7"
+      files:
+        - from: kubectl-plugins-1.1.0-beta/kubectl-bulk
+          to: "."
+      bin: ./kubectl-bulk
+  shortDescription: Prints the environment variables.
+  caveats: |
+    This plugin needs the following programs:
+    * grep
+    * sed
+  description: |
+    This plugin useful for Bulk operations.
+    You can easily do bulk operations on all resource types like deployments, services, pods etc.
+    Bulk plugin has two part, first you select resources with bulk command, then chose your command 
+    (get|list|create|update|delete|remove|rollout) with parameters.      
+          <!-- https://github.com/emreodabas/kubectl-plugins -->


### PR DESCRIPTION
Bulk plugin -> https://github.com/emreodabas/kubectl-plugins#kubectl-bulk
-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
