### PR TITLE
Upgrading rbac-lookup to 0.2.1

### DIFF
--- a/plugins/rbac-lookup.yaml
+++ b/plugins/rbac-lookup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: rbac-lookup
 spec:
   platforms:
-  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.2.0/rbac-lookup_0.2.0_Darwin_x86_64.tar.gz
-    sha256: ccf00b676d1cae3f11fe628c8b07bfc63878864a2e8e3c249b62e1984e15873b
+  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.2.1/rbac-lookup_0.2.1_Darwin_x86_64.tar.gz
+    sha256: d0e7fa8839d1e29e8cf51a9494b029fcbebfbd23c78a7bb7b2804de1b35759db
     bin: rbac-lookup
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.2.0/rbac-lookup_0.2.0_Linux_x86_64.tar.gz
-    sha256: e21d4bd665c3fbe3d66054e6faa2ab8e819d83b6cb38c04423d7b395e630154c
+  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.2.1/rbac-lookup_0.2.1_Linux_x86_64.tar.gz
+    sha256: b29b2aeb106b30708025f4495746fa25a51cad317891d13961bcca0e203c9451
     bin: rbac-lookup
     files:
     - from: "*"
@@ -24,7 +24,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  version: v0.2.0
+  version: v0.2.1
   shortDescription: Reverse lookup for RBAC
   description: |
     Easily find roles and cluster roles attached to any user, service account, or group name in your Kubernetes cluster.


### PR DESCRIPTION
This is just a small patch in rbac-lookup for OIDC auth.