### PR TITLE
Adding kube-capacity

### DIFF
--- a/plugins/resource-capacity.yaml
+++ b/plugins/resource-capacity.yaml
@@ -1,0 +1,30 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: resource-capacity
+spec:
+  platforms:
+  - uri: https://github.com/robscott/kube-capacity/releases/download/0.1.3/kube-capacity_0.1.3_Darwin_x86_64.tar.gz
+    sha256: e11208451a9ac5fd16ba1bb911b5836b742dc20a04897fd95905f843efbb596d
+    bin: kube-capacity
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/robscott/kube-capacity/releases/download/0.1.3/kube-capacity_0.1.3_Linux_x86_64.tar.gz
+    sha256: ceb2d90843d9bc145b3137ad17355c7fef28acc2cee95953db6c917838769316
+    bin: kube-capacity
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  version: v0.1.3
+  shortDescription: Provides an overview of resource requests, limits, and utilization
+  description: |
+    A simple CLI that provides an overview of the resource requests, limits, and utilization in a Kubernetes cluster.


### PR DESCRIPTION
I'm not really sure what to name this. The upstream repo is just [kube-capacity](https://github.com/robscott/kube-capacity) which the naming guide specifically says to avoid for a plugin. Capacity is probably not specific enough. Happy to change this to something like `resource-capacity` here if that makes more sense.