### PR TITLE
Add ctx and ns plugins

### DIFF
--- a/plugins/ctx.yaml
+++ b/plugins/ctx.yaml
@@ -1,0 +1,24 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ctx
+spec:
+  version: v0.0.2
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    bin: ctx
+    files:
+    - from: ctx
+      to: .
+    uri: https://github.com/weibeld/kubectl-ctx/releases/download/v0.0.2/kubectl-ctx_v0.0.2.zip
+    sha256: 5cca554ae19a1d05212d2d8ccbfdf54421d6fc6b5a51f0a55c011e3238edbfe1
+  shortDescription: Interactively change current kubeconfig context
+  caveats: |
+    This plugin needs the following programs:
+    * fzf (https://github.com/junegunn/fzf)
+  description: |
+    This plugin allows you to change the current context of your kubeconfig
+    configuration by interactively selecting it by a fuzzy search. You can
+    also list all available contexts.

--- a/plugins/ns.yaml
+++ b/plugins/ns.yaml
@@ -1,0 +1,24 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ns
+spec:
+  version: v0.0.1
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    bin: ns
+    files:
+    - from: ns
+      to: .
+    uri: https://github.com/weibeld/kubectl-ns/releases/download/v0.0.1/kubectl-ns_v0.0.1.zip
+    sha256: 2daab27afd9f4a759beb8b91842b497e4002bc813aa70adbcf6ec167d7423bb2
+  shortDescription: Interactively change the current cluster namespace.
+  caveats: |
+    This plugin needs the following programs:
+    * fzf (https://github.com/junegunn/fzf)
+  description: |
+    This plugin allows you to easily change the cluster namespace of your current
+    kubeconfig context. This makes it easier to work with multiple namespaces in
+    the same cluster.


### PR DESCRIPTION
**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)

---

Two plugins for changing the current context and the namespace of the cluster of the current context, respectively, by fuzzy finding them with fzf ([here](https://github.com/weibeld/kubectl-ctx) and [here](https://github.com/weibeld/kubectl-ns)).

The plugin names are maybe not compatible with the naming guidelines. Do you have any suggestions what the plugins could be named? I chose them this way because it's short to type, and kubectl unfortunately doesn't yet auto-complete plugin names.

There's also  a `change-ns` plugin already in the index but it doesn't provide any means to quickly select the target namespace (e.g. by completion or fuzzy finding). So, could be good to have another plugin with a better UX at its place.
