### PR TITLE
Plugin/match name

### DIFF
--- a/plugins/match-name.yaml
+++ b/plugins/match-name.yaml
@@ -1,0 +1,40 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: kubectl-match-name
+spec:
+  version: "v0.1.2"
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin]}
+    url: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.0/kubectl-match_name-darwin-amd64.zip
+    sha256: "789e8be9da2813d92261456e57aa7f7bf283781b7358becd64d57b584d4e69d2"
+    files:
+    - from: "/darwin/kubectl-match_name"
+      to: "."
+    bin: "./kubectl-match_name"
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [linux]}
+    url: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.0/kubectl-match_name-linux-amd64.zip
+    sha256: "8027c16544ad7749d31174e762d09dc49324948e15fff71ada8e1e0620a506d2"
+    files:
+    - from: "/linux/kubectl-match_name"
+      to: "."
+    bin: "./kubectl-match_name"
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [windows]}
+    url: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.2/kubectl-match_name-windows-amd64.zip
+    sha256: "49382ef4e5e104a73a1c2aa6beac377deac5ce23fd890f1b46282f21c778fe42"
+    files:
+    - from: "/windows/kubectl-match_name.exe"
+      to: "."
+    bin: "./kubectl-match_name.exe"
+
+  shortDescription: Match names of pods and other API objects
+  caveats: |
+    API object coverage is incomplete.
+  description: |
+    This plugin allows fast regex matching for the names of pods and other API objects. It reduces typing and simplifies automation.

--- a/plugins/match-name.yaml
+++ b/plugins/match-name.yaml
@@ -1,38 +1,40 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: kubectl-match-name
+  name: match-name
 spec:
-  version: "v0.1.2"
+  version: "v0.1.3"
   platforms:
   - selector:
-      matchExpressions:
-      - {key: os, operator: In, values: [darwin]}
-    url: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.0/kubectl-match_name-darwin-amd64.zip
-    sha256: "789e8be9da2813d92261456e57aa7f7bf283781b7358becd64d57b584d4e69d2"
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.3/kubectl-match_name-darwin-amd64.zip
+    sha256: 69c72e56d96688f6d32d21d1ca111573c6568ef9f4529e8616f97e1f4d97c0d6
     files:
-    - from: "/darwin/kubectl-match_name"
+    - from: "*"
       to: "."
-    bin: "./kubectl-match_name"
+    bin: kubectl-match_name
   - selector:
-      matchExpressions:
-      - {key: os, operator: In, values: [linux]}
-    url: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.0/kubectl-match_name-linux-amd64.zip
-    sha256: "8027c16544ad7749d31174e762d09dc49324948e15fff71ada8e1e0620a506d2"
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.3/kubectl-match_name-linux-amd64.zip
+    sha256: ad1cddc5eb0f97ff7c872228fa871a09967ed00a0d10c8c36a05463dff70f413
     files:
-    - from: "/linux/kubectl-match_name"
+    - from: "*"
       to: "."
-    bin: "./kubectl-match_name"
+    bin: kubectl-match_name
   - selector:
-      matchExpressions:
-      - {key: os, operator: In, values: [windows]}
-    url: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.2/kubectl-match_name-windows-amd64.zip
-    sha256: "49382ef4e5e104a73a1c2aa6beac377deac5ce23fd890f1b46282f21c778fe42"
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/gerald1248/kubectl-match-name/releases/download/v0.1.3/kubectl-match_name-windows-amd64.zip
+    sha256: aa787ebf95abdd9cebba2010b52beea3d5b9b976ff31b5f9102e1f711aff39e8
     files:
-    - from: "/windows/kubectl-match_name.exe"
+    - from: "*"
       to: "."
-    bin: "./kubectl-match_name.exe"
-
+    bin: kubectl-match_name.exe
   shortDescription: Match names of pods and other API objects
   caveats: |
     API object coverage is incomplete.


### PR DESCRIPTION
The match-name plugin is available for Linux, Mac and Windows. Its usage is:
```
$ kubectl match-name -h
Usage: kubectl match-name [-kubeconfig=PATH] [-Aa] [-k KIND] [-n NAMESPACE] REGEX
  -A	match in all namespaces
  -a	return all matching objects
  -c	count matching objects (implies -a)
  -k string
    	match objects of kind (default "pod")
  -kubeconfig string
    	absolute path to the kubeconfig file
  -n string
    	namespace
```
The source repo is https://github.com/gerald1248/kubectl-match-name.
 
-----

**Checklist for plugin developers:**

- [X] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [X] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
