### PR TITLE
Add "get-all"

### DIFF
--- a/plugins/get-all.yaml
+++ b/plugins/get-all.yaml
@@ -36,12 +36,21 @@ spec:
           os: windows
           arch: amd64
   shortDescription: Like 'kubectl get all', but get _really_ all resources
-  caveats: This plugin needs cluster admin rights, because it retrieves everything
+  caveats: |
+      Usage:
+        kubectl get-all
+
+      Documentation:
+        https://github.com/corneliusweig/ketall/blob/master/doc/USAGE.md
+
+      This plugin needs requires unrestricted access to your cluster
   description: |+2
 
+      Like 'kubectl get all', but get _really_ all resources
+
       For a complete overview of all resources in a kubernetes cluster,
+       $ kubectl get all --all-namespaces
+      is not enough, because it simply does not show everything. This helper
+      lists _really_ all resources the cluster has to offer.
 
-      $ kubectl get all --all-namespaces
-
-      is not enough, because it only lists namespaced resources. This helper will list
-      all resources the cluster has to offer.
+      https://github.com/corneliusweig/ketall#ketall

--- a/plugins/get-all.yaml
+++ b/plugins/get-all.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: get-all
+spec:
+  version: "v0.0.1"
+  platforms:
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.1/bundle.tar.gz
+      sha256: 3ec69406ad0b912c4817c37a07a4b3e7866c46dbfaa6d5b3a2db43004374c43f
+      bin: kubectl-get-all
+      files:
+        - from: ./ketall-linux-amd64
+          to: kubectl-get-all
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.1/bundle.tar.gz
+      sha256: 3ec69406ad0b912c4817c37a07a4b3e7866c46dbfaa6d5b3a2db43004374c43f
+      bin: kubectl-get-all
+      files:
+        - from: ./ketall-darwin-amd64
+          to: kubectl-get-all
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.1/bundle.tar.gz
+      sha256: 3ec69406ad0b912c4817c37a07a4b3e7866c46dbfaa6d5b3a2db43004374c43f
+      bin: kubectl-get-all.exe
+      files:
+        - from: ./ketall-windows-amd64
+          to: kubectl-get-all.exe
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+  shortDescription: Like 'kubectl get all', but get _really_ all resources
+  caveats: This plugin needs cluster admin rights, because it retrieves everything
+  description: |+2
+
+      For a complete overview of all resources in a kubernetes cluster,
+
+      $ kubectl get all --all-namespaces
+
+      is not enough, because it only lists namespaced resources. This helper will list
+      all resources the cluster has to offer.


### PR DESCRIPTION
`kubectl get all` does not list cluster-scoped resources.
This is a helper that lists _really_ all resources on the cluster.
The helper will be made available as `kubectl get-all`.

Idea-by: https://twitter.com/ahmetb/status/1095374856156196864
Signed-off-by: Cornelius Weig <cornelius.weig@tngtech.com>

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
