### PR TITLE
get-all 0.0.2

### DIFF
--- a/plugins/get-all.yaml
+++ b/plugins/get-all.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: get-all
 spec:
-  version: "v0.0.1"
+  version: "v0.0.2"
   platforms:
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.1/bundle.tar.gz
-      sha256: 3ec69406ad0b912c4817c37a07a4b3e7866c46dbfaa6d5b3a2db43004374c43f
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.2/bundle.tar.gz
+      sha256: afafeb57dc625c47e5b0363cd7aad162377999a3f5f888f44c0aa8b080402f9d
       bin: kubectl-get-all
       files:
         - from: ./ketall-linux-amd64
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.1/bundle.tar.gz
-      sha256: 3ec69406ad0b912c4817c37a07a4b3e7866c46dbfaa6d5b3a2db43004374c43f
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.2/bundle.tar.gz
+      sha256: afafeb57dc625c47e5b0363cd7aad162377999a3f5f888f44c0aa8b080402f9d
       bin: kubectl-get-all
       files:
         - from: ./ketall-darwin-amd64
@@ -25,8 +25,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.1/bundle.tar.gz
-      sha256: 3ec69406ad0b912c4817c37a07a4b3e7866c46dbfaa6d5b3a2db43004374c43f
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.2/bundle.tar.gz
+      sha256: afafeb57dc625c47e5b0363cd7aad162377999a3f5f888f44c0aa8b080402f9d
       bin: kubectl-get-all.exe
       files:
         - from: ./ketall-windows-amd64
@@ -35,7 +35,7 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-  shortDescription: Like 'kubectl get all', but get _really_ all resources
+  shortDescription: Like 'kubectl get all', but _really_ everything
   caveats: |
       Usage:
         kubectl get-all
@@ -43,7 +43,7 @@ spec:
       Documentation:
         https://github.com/corneliusweig/ketall/blob/master/doc/USAGE.md
 
-      This plugin needs requires unrestricted access to your cluster
+      This plugin requires unrestricted access to your cluster
   description: |+2
 
       Like 'kubectl get all', but get _really_ all resources


### PR DESCRIPTION
This version fixes a bug with json/yaml formatting.

Signed-off-by: Cornelius Weig <cornelius.weig@tngtech.com>

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
