### PR TITLE
Bump version of "get-all" to v0.0.3

### DIFF
--- a/plugins/get-all.yaml
+++ b/plugins/get-all.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: get-all
 spec:
-  version: "v0.0.2"
+  version: "v0.0.3"
   platforms:
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.2/bundle.tar.gz
-      sha256: afafeb57dc625c47e5b0363cd7aad162377999a3f5f888f44c0aa8b080402f9d
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.3/bundle.tar.gz
+      sha256: bd8564ff59a4090e4d135a23937a2024b5cd86b59a804a6da03a1a5f67718b5d
       bin: kubectl-get-all
       files:
         - from: ./ketall-linux-amd64
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.2/bundle.tar.gz
-      sha256: afafeb57dc625c47e5b0363cd7aad162377999a3f5f888f44c0aa8b080402f9d
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.3/bundle.tar.gz
+      sha256: bd8564ff59a4090e4d135a23937a2024b5cd86b59a804a6da03a1a5f67718b5d
       bin: kubectl-get-all
       files:
         - from: ./ketall-darwin-amd64
@@ -25,8 +25,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.2/bundle.tar.gz
-      sha256: afafeb57dc625c47e5b0363cd7aad162377999a3f5f888f44c0aa8b080402f9d
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v0.0.3/bundle.tar.gz
+      sha256: bd8564ff59a4090e4d135a23937a2024b5cd86b59a804a6da03a1a5f67718b5d
       bin: kubectl-get-all.exe
       files:
         - from: ./ketall-windows-amd64
@@ -41,7 +41,7 @@ spec:
         kubectl get-all
 
       Documentation:
-        https://github.com/corneliusweig/ketall/blob/master/doc/USAGE.md
+        https://github.com/corneliusweig/ketall/blob/v0.0.3/doc/USAGE.md#usage
 
       This plugin requires unrestricted access to your cluster
   description: |+2


### PR DESCRIPTION
This version excludes events from being shown by default.

Also see https://github.com/corneliusweig/ketall/releases/tag/v0.0.3

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
