### PR TITLE
Update cssh plugin to v1.0.1

### DIFF
--- a/plugins/cssh.yaml
+++ b/plugins/cssh.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: cssh
 spec:
-  version: "v1.0.0"
+  version: "v1.0.1"
   platforms:
-  - uri: https://github.com/containership/kubectl-cssh/archive/v1.0.0.tar.gz
-    sha256: c638dcc802d2d52ce0ec2283a2f9d217eaa17855f3edd702229571da39c1ab84
+  - uri: https://github.com/containership/kubectl-cssh/archive/v1.0.1.tar.gz
+    sha256: 207cf5c1cf947183851b51f6a3afdb7ed9e98e52d49e49b76c74d3f5845e452b
     bin: kubectl-cssh
     files:
     - from: "/*/parse-args.sh"


### PR DESCRIPTION
Update cssh plugin to version v1.0.1
-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
