### PR TITLE
view-utilization release v0.2.0

### DIFF
--- a/plugins/view-utilization.yaml
+++ b/plugins/view-utilization.yaml
@@ -3,13 +3,13 @@ kind: Plugin
 metadata:
   name: view-utilization
 spec:
-  version: "v0.1.4"
+  version: "v0.2.0"
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/etopeter/kubectl-view-utilization/releases/download/v0.1.4/kubectl-view-utilization-v0.1.4.tar.gz
-    sha256: "3b7c708ad710a1b815ede32415e1d4d295da7e896fe9e866be845d00cd2a67ac"
+    uri: https://github.com/etopeter/kubectl-view-utilization/releases/download/v0.2.0/kubectl-view-utilization-v0.2.0.tar.gz
+    sha256: "ca284134fa96fc13b2d920c22c87f8c7c621d2b1ee93c9706663c650bc724bd6"
     bin: "kubectl-view-utilization"
     files:
     - from: "*"


### PR DESCRIPTION
-----
Latest release of plugin view-utilization v0.2.0
**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [ x]Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
