### PR TITLE
Bump version of "access-matrix" to v0.1.1

### DIFF
--- a/plugins/access-matrix.yaml
+++ b/plugins/access-matrix.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: access-matrix
 spec:
-  version: "v0.1.0"
+  version: "v0.1.1"
   platforms:
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.1.0/bundle.tar.gz
-      sha256: ce67b41ba92cb8bed2332916e5fc019edec634129f2a2d105a3c1f71e8580170
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.1.1/bundle.tar.gz
+      sha256: df2da718d8eee1b05e9695119a1a9142284eced1267a5d2f549814fbdc315f61
       bin: rakkess-linux-amd64
       files:
         - from: ./rakkess-linux-amd64
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.1.0/bundle.tar.gz
-      sha256: ce67b41ba92cb8bed2332916e5fc019edec634129f2a2d105a3c1f71e8580170
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.1.1/bundle.tar.gz
+      sha256: df2da718d8eee1b05e9695119a1a9142284eced1267a5d2f549814fbdc315f61
       bin: rakkess-darwin-amd64
       files:
         - from: ./rakkess-darwin-amd64
@@ -25,8 +25,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.1.0/bundle.tar.gz
-      sha256: ce67b41ba92cb8bed2332916e5fc019edec634129f2a2d105a3c1f71e8580170
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.1.1/bundle.tar.gz
+      sha256: df2da718d8eee1b05e9695119a1a9142284eced1267a5d2f549814fbdc315f61
       bin: rakkess-windows-amd64.exe
       files:
         - from: ./rakkess-windows-amd64
@@ -41,7 +41,7 @@ spec:
         kubectl access-matrix
 
       Documentation:
-        https://github.com/corneliusweig/rakkess/blob/v0.1.0/doc/USAGE.md#usage
+        https://github.com/corneliusweig/rakkess/blob/v0.1.1/doc/USAGE.md#usage
   description: |+2
 
       Show an access matrix for all server resources
@@ -51,4 +51,4 @@ spec:
       This complements the usual "kubectl auth can-i" command, which works for
       a single resource and a single verb.
 
-      More on https://github.com/corneliusweig/rakkess/blob/v0.1.0/doc/USAGE.md#usage
+      More on https://github.com/corneliusweig/rakkess/blob/v0.1.1/doc/USAGE.md#usage


### PR DESCRIPTION
This fixes an issue with authentication plugins

Release notes:
https://github.com/corneliusweig/rakkess/releases/tag/v0.1.1

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
