### PR TITLE
Updating rbac-lookup to 0.3.0

### DIFF
--- a/plugins/rbac-lookup.yaml
+++ b/plugins/rbac-lookup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: rbac-lookup
 spec:
   platforms:
-  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.2.1/rbac-lookup_0.2.1_Darwin_x86_64.tar.gz
-    sha256: d0e7fa8839d1e29e8cf51a9494b029fcbebfbd23c78a7bb7b2804de1b35759db
+  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.3.0/rbac-lookup_0.3.0_Darwin_x86_64.tar.gz
+    sha256: 7a271bddae25bc178079815954e957c80c8d7d95a060b537128ebf800692492b
     bin: rbac-lookup
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.2.1/rbac-lookup_0.2.1_Linux_x86_64.tar.gz
-    sha256: b29b2aeb106b30708025f4495746fa25a51cad317891d13961bcca0e203c9451
+  - uri: https://github.com/reactiveops/rbac-lookup/releases/download/v0.3.0/rbac-lookup_0.3.0_Linux_x86_64.tar.gz
+    sha256: a758133ce7c0e056f6cd90dc12b33c0c0f63c8adec37041b25891e54880db141
     bin: rbac-lookup
     files:
     - from: "*"
@@ -24,7 +24,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  version: v0.2.1
+  version: v0.3.0
   shortDescription: Reverse lookup for RBAC
   description: |
     Easily find roles and cluster roles attached to any user, service account, or group name in your Kubernetes cluster.


### PR DESCRIPTION
The latest version of [rbac-lookup](https://github.com/reactiveops/rbac-lookup) adds the ability to filter by RBAC subject kind as well as improved auth.