### PR TITLE
Add homepage to open-svc

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -29,3 +29,4 @@ spec:
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser
     through a local proxy server using kubectl proxy.
+  homepage: https://github.com/superbrothers/kubectl-open-svc-plugin


### PR DESCRIPTION
This PR adds the homepage field to open-svc plugin manifest.

If there is no problem, I will create PRs to add the homepage field to other plugin manifests.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
