### PR TITLE
Add homepage field for bulk-action plugin

### DIFF
--- a/plugins/bulk-action.yaml
+++ b/plugins/bulk-action.yaml
@@ -28,3 +28,4 @@ spec:
     * sed
   description: |
     This plugin allows you to do bulk actions on Kubernetes resources.
+  homepage: https://github.com/emreodabas/kubectl-plugins#kubectl-bulk


### PR DESCRIPTION
/ref #92 /cc @emreodabas 

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
