### PR TITLE
Add homepage for ca-cert, mtail, rm-standalone-pods, view-secret plugins

### DIFF
--- a/plugins/ca-cert.yaml
+++ b/plugins/ca-cert.yaml
@@ -15,6 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "master"
+  homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Print the PEM CA certificate of the current cluster
   description: |
     Pretty print the current cluster certificate. The plugin formats the

--- a/plugins/mtail.yaml
+++ b/plugins/mtail.yaml
@@ -15,6 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "master"
+  homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Tail logs from multiple pods matching label selector
   caveats: |
     This plugin needs the following programs:

--- a/plugins/rm-standalone-pods.yaml
+++ b/plugins/rm-standalone-pods.yaml
@@ -15,6 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "master"
+  homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Remove all pods without owner references
   caveats: |
     This plugin needs the following programs:

--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -15,6 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "master"
+  homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Decode secrets
   caveats: |
     This plugin needs the following programs:


### PR DESCRIPTION
/ref #92 

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
