### PR TITLE
Add homepage for debug-shell, gke-credentials, node-admin, pod-logs, pod-shell plugins

### DIFF
--- a/plugins/debug-shell.yaml
+++ b/plugins/debug-shell.yaml
@@ -14,4 +14,5 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.2"
+  homepage: https://github.com/danisla/kubefunc
   shortDescription: Create pod with interactive kube-shell.

--- a/plugins/gke-credentials.yaml
+++ b/plugins/gke-credentials.yaml
@@ -15,6 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.1"
+  homepage: https://github.com/danisla/kubefunc
   shortDescription: Fetch credentials for GKE clusters
   caveats: |
     This plugin needs the following programs:

--- a/plugins/node-admin.yaml
+++ b/plugins/node-admin.yaml
@@ -14,4 +14,5 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.2"
+  homepage: https://github.com/danisla/kubefunc
   shortDescription: List nodes and run privileged pod with chroot

--- a/plugins/pod-logs.yaml
+++ b/plugins/pod-logs.yaml
@@ -15,4 +15,5 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.1"
+  homepage: https://github.com/danisla/kubefunc
   shortDescription: Display a list of pods to get logs from

--- a/plugins/pod-shell.yaml
+++ b/plugins/pod-shell.yaml
@@ -15,4 +15,5 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.1"
+  homepage: https://github.com/danisla/kubefunc
   shortDescription: Display a list of pods to execute a shell in


### PR DESCRIPTION
/ref #92 /cc @danisla 

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
