### PR TITLE
Add homepage for prompt plugin

### DIFF
--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -15,6 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.0-krew"
+  homepage: https://github.com/jordanwilson230/kubectl-plugins#kubectl-prompt
   caveats: |
     This plugin requires bash.
     When removing this plugin, delete the line beginning with `function kubectl()` and `KUBECTL_*_PROMPT` in your ~/.bash_profile.


### PR DESCRIPTION
/ref #92 /cc @jordanwilson230

-----

**Checklist for plugin developers:**

- [ ] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [ ] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
