### PR TITLE
Add homepage for match-name plugin

### DIFF
--- a/plugins/match-name.yaml
+++ b/plugins/match-name.yaml
@@ -35,6 +35,7 @@ spec:
     - from: "*"
       to: "."
     bin: kubectl-match_name.exe
+  homepage: https://github.com/gerald1248/kubectl-match-name
   shortDescription: Match names of pods and other API objects
   caveats: |
     API object coverage is incomplete.


### PR DESCRIPTION
/ref #92 /cc @gerald1248

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
