### PR TITLE
Add homepage for ssh-jump plugin

### DIFF
--- a/plugins/ssh-jump.yaml
+++ b/plugins/ssh-jump.yaml
@@ -4,6 +4,7 @@ metadata:
   name: ssh-jump
 spec:
   version: "0.1.0"
+  homepage: https://github.com/yokawasa/kubectl-plugin-ssh-jump
   platforms:
   - selector:
       matchExpressions:


### PR DESCRIPTION
/ref #92 /cc @yokawasa 

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
