### PR TITLE
Add homepage for sudo plugin

### DIFF
--- a/plugins/sudo.yaml
+++ b/plugins/sudo.yaml
@@ -5,6 +5,7 @@ metadata:
   name: sudo
 spec:
   version: "v1.0.1"
+  homepage: https://github.com/postfinance/kubectl-sudo
   platforms:
   - selector:
       matchExpressions:


### PR DESCRIPTION
/ref #92 /cc @djboris9 

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
