### PR TITLE
Add homepage fields.

### DIFF
--- a/plugins/exec-as.yaml
+++ b/plugins/exec-as.yaml
@@ -16,5 +16,6 @@ spec:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.0-krew"
   caveats: The node which the pod is running on cannot have more than one taint.
+  homepage: https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-exec-as
   shortDescription: Like kubectl exec, but offers a `user` flag to exec as root or any other user.
   description: Run `kubectl exec-as` for usage. Example, `kubectl exec-as -u root -p zookeeper-0`.

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -15,7 +15,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
   version: "v1.0.0-krew"
-  homepage: https://github.com/jordanwilson230/kubectl-plugins#kubectl-prompt
+  homepage: https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-prompt
   caveats: |
     This plugin requires bash.
     When removing this plugin, delete the line beginning with `function kubectl()` and `KUBECTL_*_PROMPT` in your ~/.bash_profile.


### PR DESCRIPTION
Adds a homepage field to the exec-as and prompt plugin manifests.
The homepage README has been revised to provide clear instructions, specific for the Krew plugins.


-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
