### PR TITLE
Update plugin "get-all" to v1.1.0

### DIFF
--- a/plugins/get-all.yaml
+++ b/plugins/get-all.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: get-all
 spec:
-  version: "v1.0.2"
+  version: "v1.1.0"
   platforms:
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v1.0.2/bundle.tar.gz
-      sha256: a716693abe62dd746d641b75cc1aba50ba9452f61076ac2090e810ddad29a818
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v1.1.0/bundle.tar.gz
+      sha256: 59ddc1715d4ea99dcd76ffb6910044a6e1e04dc1df6ad595ce4fe9410b1a2e6b
       bin: ketall-linux-amd64
       files:
         - from: ./ketall-linux-amd64
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v1.0.2/bundle.tar.gz
-      sha256: a716693abe62dd746d641b75cc1aba50ba9452f61076ac2090e810ddad29a818
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v1.1.0/bundle.tar.gz
+      sha256: 59ddc1715d4ea99dcd76ffb6910044a6e1e04dc1df6ad595ce4fe9410b1a2e6b
       bin: ketall-darwin-amd64
       files:
         - from: ./ketall-darwin-amd64
@@ -25,8 +25,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/corneliusweig/ketall/releases/download/v1.0.2/bundle.tar.gz
-      sha256: a716693abe62dd746d641b75cc1aba50ba9452f61076ac2090e810ddad29a818
+    - uri: https://github.com/corneliusweig/ketall/releases/download/v1.1.0/bundle.tar.gz
+      sha256: 59ddc1715d4ea99dcd76ffb6910044a6e1e04dc1df6ad595ce4fe9410b1a2e6b
       bin: ketall-windows-amd64.exe
       files:
         - from: ./ketall-windows-amd64
@@ -42,7 +42,7 @@ spec:
         kubectl get-all
 
       Documentation:
-        https://github.com/corneliusweig/ketall/blob/v1.0.2/doc/USAGE.md#usage
+        https://github.com/corneliusweig/ketall/blob/v1.1.0/doc/USAGE.md#usage
   description: |+2
 
       Like 'kubectl get all', but get _really_ all resources
@@ -52,4 +52,4 @@ spec:
       is not enough, because it simply does not show everything. This helper
       lists _really_ all resources the cluster has to offer.
 
-      More on https://github.com/corneliusweig/ketall/blob/v1.0.2/doc/USAGE.md#usage
+      More on https://github.com/corneliusweig/ketall/blob/v1.1.0/doc/USAGE.md#usage


### PR DESCRIPTION
Release notes:
* Flag `--namespace` now implies `--only-scope=namespace`
[#18](https://github.com/corneliusweig/ketall/pull/18)
* Add new flag `--since` to filter resources by creation timestamp
[#17](https://github.com/corneliusweig/ketall/pull/17)
* Fix travis releases
[#15](https://github.com/corneliusweig/ketall/pull/15)

Signed-off-by: Cornelius Weig <22861411+corneliusweig@users.noreply.github.com>

-----

**Checklist for plugin developers:**

- [ ] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [ ] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
