### PR TITLE
Bump the version of view-serviceaccount-kubeconfig to v2.0.1

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,8 +4,8 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.0.0/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
-    sha256: e5394ff39cdc5906a54e0acfd03a31a609b12dce78a88fd66ede48727df1416c
+  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.0.1/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
+    sha256: "fd6fec491fdec877829931d6b49d6ed7bb739647dfd7b33d43e214d98306d9ca"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: "kubectl-view_serviceaccount_kubeconfig"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.0.0/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
-    sha256: 611c5b5fa13b31e6b4f3c38dd169f821b96b4c19f5a5b31845a6eb42ecdb9a31
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.0.1/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: "286266e5db62a77fb6d7c3c798d8530e19b7267f389783f35a5fea3433ebd0f5"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: "kubectl-view_serviceaccount_kubeconfig"
@@ -24,7 +24,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  version: v2.0.0
+  version: "v2.0.1"
   homepage: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
This PR bumps the version of view-serviceaccount-kubeconfig to v2.0.1.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
